### PR TITLE
[LIVY-758] Document how to attach to an existing session from Java client

### DIFF
--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -36,6 +36,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public final class LivyClientBuilder {
 
   public static final String LIVY_URI_KEY = "livy.uri";
+  public static final String LIVY_SESSION_ID_KEY = "livy.sessionId";
 
   private static final ServiceLoader<LivyClientFactory> CLIENT_FACTORY_LOADER =
     ServiceLoader.load(LivyClientFactory.class, classLoader());
@@ -96,8 +97,30 @@ public final class LivyClientBuilder {
     }
   }
 
+  /**
+   * Set the URI of the Livy server the client will connect to.
+   * If the URI contains <pre>sessions/{sessionId}</pre>,
+   * the client will connect to the specified existing session,
+   * otherwise it will create a new session.
+   *
+   * @param uri The URI of Livy server.
+   * @return The builder itself.
+   */
   public LivyClientBuilder setURI(URI uri) {
     config.setProperty(LIVY_URI_KEY, uri.toString());
+    return this;
+  }
+
+  /**
+   * Sets the sessionId the client will connect to. If sessionId is set,
+   * all Spark configurations will be ignored and the original session ones will be used.
+   * If not set, a new session will be created when the client is built.
+   *
+   * @param sessionId The ID of the session to attach to.
+   * @return the builder itself.
+   */
+  public LivyClientBuilder setSessionId(int sessionId) {
+    config.setProperty(LIVY_SESSION_ID_KEY, String.valueOf(sessionId));
     return this;
   }
 

--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -98,9 +98,8 @@ public final class LivyClientBuilder {
   }
 
   /**
-   * Sets the URI of the Livy server the client will connect to.
-   * If the URI contains <pre>sessions/{sessionId}</pre>,
-   * the client will connect to the specified existing session;
+   * Sets the URI of the Livy server the client will connect to. If the URI contains
+   * <pre>sessions/{sessionId}</pre>, the client will connect to the specified existing session;
    * otherwise it will create a new session.
    *
    * @param uri The URI of Livy server.
@@ -112,9 +111,9 @@ public final class LivyClientBuilder {
   }
 
   /**
-   * Sets the session ID the client will connect to. If a session ID is set,
-   * the chosen session will be used with its own configurations, so Spark configurations will be ignored.
-   * If not set, a new session will be created when the client is built.
+   * Sets the session ID the client will connect to. If a session ID is set, the chosen session
+   * will be used with its own configurations, so Spark configurations will be ignored. If not set,
+   * a new session will be created when the client is built.
    *
    * @param sessionId The ID of the session to attach to.
    * @return the builder itself.

--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -100,7 +100,7 @@ public final class LivyClientBuilder {
   /**
    * Set the URI of the Livy server the client will connect to.
    * If the URI contains <pre>sessions/{sessionId}</pre>,
-   * the client will connect to the specified existing session,
+   * the client will connect to the specified existing session;
    * otherwise it will create a new session.
    *
    * @param uri The URI of Livy server.

--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -112,7 +112,7 @@ public final class LivyClientBuilder {
   }
 
   /**
-   * Sets the sessionId the client will connect to. If sessionId is set,
+   * Sets the session ID the client will connect to. If a session ID is set,
    * the chosen session will be used with its own configurations, so Spark configurations will be ignored.
    * If not set, a new session will be created when the client is built.
    *

--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -98,7 +98,7 @@ public final class LivyClientBuilder {
   }
 
   /**
-   * Set the URI of the Livy server the client will connect to.
+   * Sets the URI of the Livy server the client will connect to.
    * If the URI contains <pre>sessions/{sessionId}</pre>,
    * the client will connect to the specified existing session;
    * otherwise it will create a new session.

--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -113,7 +113,7 @@ public final class LivyClientBuilder {
 
   /**
    * Sets the sessionId the client will connect to. If sessionId is set,
-   * all Spark configurations will be ignored and the original session ones will be used.
+   * the chosen session will be used with its own configurations, so Spark configurations will be ignored.
    * If not set, a new session will be created when the client is built.
    *
    * @param sessionId The ID of the session to attach to.

--- a/client-http/src/test/scala/org/apache/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/HttpClientSpec.scala
@@ -181,13 +181,32 @@ class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUni
       testJob(false, response = Some(null))
     }
 
-    withClient("should connect to existing sessions") {
-      var sid = client.asInstanceOf[HttpClient].getSessionId()
+    withClient("should connect to existing sessions using the URI") {
+      val sid = client.asInstanceOf[HttpClient].getSessionId()
       val uri = s"http://${InetAddress.getLocalHost.getHostAddress}:${server.port}" +
         s"${LivyConnection.SESSIONS_URI}/$sid"
       val newClient = new LivyClientBuilder(false).setURI(new URI(uri)).build()
       newClient.stop(false)
       verify(session, never()).stop()
+    }
+
+    withClient("should connect to existing sessions using the conf") {
+      val sid = client.asInstanceOf[HttpClient].getSessionId()
+      val uri = s"http://${InetAddress.getLocalHost.getHostAddress}:${server.port}"
+      val newClient = new LivyClientBuilder(false).setURI(new URI(uri)).setSessionId(sid).build()
+      newClient.stop(false)
+      verify(session, never()).stop()
+    }
+
+    withClient("should throw an exception if the sessionId is set through conf and URI") {
+      val sid = client.asInstanceOf[HttpClient].getSessionId()
+      val uri = s"http://${InetAddress.getLocalHost.getHostAddress}:${server.port}" +
+        s"${LivyConnection.SESSIONS_URI}/$sid"
+      intercept[IllegalArgumentException]{
+        val newClient = new LivyClientBuilder(false).setURI(new URI(uri)).setSessionId(sid).build()
+        newClient.stop(false)
+        verify(session, never()).stop()
+      }
     }
 
     withClient("should tear down clients") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add an explicit way to set the session when connecting from the Java client.
https://issues.apache.org/jira/browse/LIVY-758

## How was this patch tested?

Unit tested through `HttpClientSpec`.
