### PR TITLE
[LIVY-1080] Add missing properties that allows to configure kinit thread

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -183,6 +183,12 @@
 # livy.server.auth.kerberos.keytab = <spnego keytab>
 # livy.server.auth.kerberos.name-rules = DEFAULT
 #
+# Principal and keytab for Livy server.
+# livy.server.launch.kerberos.principal = <livy principal>
+# livy.server.launch.kerberos.keytab = <livy keytab>
+# livy.server.launch.kerberos.refresh-interval = 1h
+# livy.server.launch.kerberos.kinit-fail-threshold = 5
+#
 # If user wants to use custom authentication filter, configurations are:
 # livy.server.auth.type = <custom>
 # livy.server.auth.<custom>.class = <class of custom auth filter>


### PR DESCRIPTION
JIRA: [LIVY-1080](https://issues.apache.org/jira/browse/LIVY-1080)

## What changes were proposed in this pull request?

This properties allow to configure kinit thread and not documented anywhere except for the code:
https://github.com/apache/incubator-livy/blob/86fc823/server/src/main/scala/org/apache/livy/LivyConf.scala#L106-L109
https://github.com/apache/incubator-livy/blob/86fc823/server/src/main/scala/org/apache/livy/server/LivyServer.scala#L106-L141

## How was this patch tested?

Manual

## Was this patch authored or co-authored using generative AI tooling?

No