### PR TITLE
[LIVY-1063] Fix resource leak in Kubernetes service account token refresh

### DIFF
--- a/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
@@ -76,27 +76,45 @@ object SparkKubernetesApp extends Logging {
     }
   }
 
+  /**
+   * Reload the OAuth token into the existing client configuration in place. Reuses the
+   * KubernetesClient created at startup; does not create a new one.
+   */
+  private[utils] def refreshServiceAccountToken(
+      client: KubernetesClient,
+      autoConfigure: String => Config = Config.autoConfigure(_)): Unit = {
+    val config = client.getConfiguration
+    val contextName = Option(config.getCurrentContext).map(_.getName).getOrElse("")
+    val newestConfig = autoConfigure(contextName)
+    config.setOauthToken(newestConfig.getOauthToken)
+  }
+
   val RefreshServiceAccountTokenThread = new Thread() {
+    private val tokenRefreshIntervalMs = 300000L
+
     override def run(): Unit = {
-      while (true) {
-        var currentContext = new Context()
-        var currentContextName = new String
-        val config = kubernetesClient.getConfiguration
-        if (config.getCurrentContext != null) {
-          currentContext = config.getCurrentContext.getContext
-          currentContextName = config.getCurrentContext.getName
+      while (!Thread.currentThread().isInterrupted) {
+        try {
+          refreshServiceAccountToken(kubernetesClient)
+          info("Refreshed Kubernetes service account token.")
+        } catch {
+          case e: InterruptedException =>
+            Thread.currentThread().interrupt()
+            warn("RefreshServiceAccountTokenThread was interrupted, exiting.", e)
+            return
+          case NonFatal(e) =>
+            warn("Failed to refresh Kubernetes service account token, will retry.", e)
         }
 
-        var newAccessToken = new String
-        val newestConfig = Config.autoConfigure(currentContextName)
-        newAccessToken = newestConfig.getOauthToken
-        info("Refreshed Kubernetes service account token.")
-
-        config.setOauthToken(newAccessToken)
-        kubernetesClient = new DefaultKubernetesClient(config)
-
-        // Token will expire 1 hour default, community recommend to update every 5 minutes
-        Thread.sleep(300000)
+        // Sleep runs after both success and failure to avoid a hot retry loop.
+        try {
+          Thread.sleep(tokenRefreshIntervalMs)
+        } catch {
+          case e: InterruptedException =>
+            Thread.currentThread().interrupt()
+            warn("RefreshServiceAccountTokenThread was interrupted, exiting.", e)
+            return
+        }
       }
     }
   }

--- a/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
@@ -20,7 +20,7 @@ import java.util.Objects._
 
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.api.model.networking.v1.{Ingress, IngressRule, IngressSpec}
-import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient, KubernetesClient}
 import org.mockito.Mockito.when
 import org.scalatest.{BeforeAndAfterAll, FunSpec}
 import org.scalatestplus.mockito.MockitoSugar._
@@ -45,6 +45,33 @@ class SparkKubernetesAppSpec extends FunSpec with LivyBaseUnitTestSuite with Bef
   override def afterAll(): Unit = {
     super.afterAll()
     assert(SparkKubernetesApp.getAppSize === 0)
+  }
+
+  describe("refreshServiceAccountToken") {
+    it("should reload the OAuth token into the existing config using the current context") {
+      val clientConfig = new ConfigBuilder().withOauthToken("old-token").build()
+      val namedContext = new NamedContext()
+      namedContext.setName("prod-context")
+      clientConfig.setCurrentContext(namedContext)
+
+      // DefaultKubernetesClient is used only so getConfiguration returns a concrete Config
+      // (the interface's generic return type makes the Mockito stub ambiguous).
+      val client = mock[DefaultKubernetesClient]
+      when(client.getConfiguration).thenReturn(clientConfig)
+
+      var capturedContextName: String = null
+      SparkKubernetesApp.refreshServiceAccountToken(
+        client,
+        contextName => {
+          capturedContextName = contextName
+          new ConfigBuilder().withOauthToken("new-token").build()
+        }
+      )
+
+      assert(capturedContextName === "prod-context")
+      // Same config object is mutated in place; no new KubernetesClient is created.
+      assert(clientConfig.getOauthToken === "new-token")
+    }
   }
 
   describe("KubernetesAppReport") {


### PR DESCRIPTION

## What changes were proposed in this pull request?

Reuse the existing `KubernetesClient` during service account token refresh instead of
recreating `DefaultKubernetesClient` every 5 minutes without closing the old client.

JIRA: https://issues.apache.org/jira/browse/LIVY-1063

## How was this patch tested?

- Existing unit tests: `mvn -pl server -am -DskipITs test`
- Manual review: refresh loop only calls `config.setOauthToken()`; no new client creation
- Manual testing: deployed on Kubernetes with in-cluster SA auth;
  verified "Refreshed Kubernetes service account token." logs every ~5 minutes and
  native/HTTP client thread count remains stable over several refresh cycles

## Was this patch authored or co-authored using generative AI tooling?

Yes, used Cursor AI to write down the test case.
