### PR TITLE
[LIVY-1065] Ensure all tests pass on macOS

### DIFF
--- a/client-common/src/main/java/org/apache/livy/client/common/TestUtils.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/TestUtils.java
@@ -33,6 +33,14 @@ import org.apache.livy.annotations.Private;
 public class TestUtils {
 
   /**
+   * Loopback address for test services. Pinned to 127.0.0.1 so tests do not resolve macOS
+   * canonical hostnames that are unreachable from peer processes on the same host (see
+   * LIVY-1065). Reused for Livy server host, Thrift bind host, RSC RPC server address, and
+   * Spark driver / executor / YARN AM local IPs in the test layer.
+   */
+  public static final String TEST_BIND_HOST = "127.0.0.1";
+
+  /**
    * Returns JVM arguments that enable jacoco on a process to be run. The returned arguments
    * create a new, unique output file in the same directory referenced by the "jacoco.args"
    * system property.

--- a/client-http/src/test/scala/org/apache/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/HttpClientSpec.scala
@@ -18,7 +18,7 @@
 package org.apache.livy.client.http
 
 import java.io.{File, InputStream}
-import java.net.{InetAddress, URI}
+import java.net.URI
 import java.nio.file.{Files, Paths}
 import java.util.concurrent.{Future => JFuture, _}
 import java.util.concurrent.atomic.AtomicLong
@@ -35,7 +35,7 @@ import org.scalatra.LifeCycle
 import org.scalatra.servlet.ScalatraListener
 
 import org.apache.livy._
-import org.apache.livy.client.common.{BufferUtils, Serializer}
+import org.apache.livy.client.common.{BufferUtils, Serializer, TestUtils}
 import org.apache.livy.client.common.HttpMessages._
 import org.apache.livy.server.{AccessManager, WebServer}
 import org.apache.livy.server.interactive.{InteractiveSession, InteractiveSessionServlet}
@@ -62,7 +62,7 @@ class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUni
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    server = new WebServer(new LivyConf(), "0.0.0.0", 0)
+    server = new WebServer(new LivyConf(), TestUtils.TEST_BIND_HOST, 0)
 
     server.context.setResourceBase("src/main/org/apache/livy/server")
     server.context.setInitParameter(ScalatraListener.LifeCycleKey,
@@ -88,9 +88,7 @@ class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUni
   describe("HTTP client library") {
 
     it("should create clients") {
-      // WebServer does this internally instead of respecting "0.0.0.0", so try to use the same
-      // address.
-      val uri = s"http://${InetAddress.getLocalHost.getHostAddress}:${server.port}/"
+      val uri = s"http://${server.host}:${server.port}/"
       client = new LivyClientBuilder(false).setURI(new URI(uri)).build()
     }
 
@@ -183,7 +181,8 @@ class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUni
 
     withClient("should connect to existing sessions") {
       var sid = client.asInstanceOf[HttpClient].getSessionId()
-      val uri = s"http://${InetAddress.getLocalHost.getHostAddress}:${server.port}" +
+      // Match the loopback address the WebServer bound to (see beforeAll).
+      val uri = s"http://${server.host}:${server.port}" +
         s"${LivyConnection.SESSIONS_URI}/$sid"
       val newClient = new LivyClientBuilder(false).setURI(new URI(uri)).build()
       newClient.stop(false)

--- a/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
@@ -30,6 +30,7 @@ import org.scalatest.Matchers._
 import org.scalatra.servlet.ScalatraListener
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
+import org.apache.livy.client.common.TestUtils
 import org.apache.livy.server.WebServer
 
 class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
@@ -64,7 +65,7 @@ class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBas
     def test(password: String, livyConf: LivyConf = new LivyConf()): Unit = {
       val username = "user name"
 
-      val server = new WebServer(livyConf, "0.0.0.0", 0)
+      val server = new WebServer(livyConf, TestUtils.TEST_BIND_HOST, 0)
       server.context.setSecurityHandler(basicAuth(username, password, "realm"))
       server.context.setResourceBase("src/main/org/apache/livy/server")
       server.context.setInitParameter(ScalatraListener.LifeCycleKey,

--- a/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
@@ -36,6 +36,7 @@ import org.scalatest.concurrent.Eventually._
 
 import org.apache.livy.{LivyConf, Logging}
 import org.apache.livy.client.common.TestUtils
+import org.apache.livy.rsc.RSCConf
 import org.apache.livy.server.LivyServer
 
 private class MiniClusterConfig(val config: Map[String, String]) {
@@ -136,7 +137,10 @@ object MiniLivyMain extends MiniClusterBase {
       LivyConf.YARN_POLL_INTERVAL.key -> "500ms",
       LivyConf.RECOVERY_MODE.key -> "recovery",
       LivyConf.RECOVERY_STATE_STORE.key -> "filesystem",
-      LivyConf.RECOVERY_STATE_STORE_URL.key -> s"file://$configPath/state-store")
+      LivyConf.RECOVERY_STATE_STORE_URL.key -> s"file://$configPath/state-store",
+      LivyConf.SERVER_HOST.key -> TestUtils.TEST_BIND_HOST,
+      LivyConf.THRIFT_BIND_HOST.key -> TestUtils.TEST_BIND_HOST,
+      RSCConf.Entry.RPC_SERVER_ADDRESS.key() -> TestUtils.TEST_BIND_HOST)
     val thriftEnabled = sys.env.get("LIVY_TEST_THRIFT_ENABLED")
     if (thriftEnabled.nonEmpty && thriftEnabled.forall(_.toBoolean)) {
       baseConf + (LivyConf.THRIFT_SERVER_ENABLED.key -> "true")
@@ -237,6 +241,16 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
       "spark.executor.instances" -> "1",
       "spark.scheduler.minRegisteredResourcesRatio" -> "0.0",
       "spark.ui.enabled" -> "false",
+      "spark.driver.host" -> TestUtils.TEST_BIND_HOST,
+      "spark.yarn.appMasterEnv.SPARK_LOCAL_IP" -> TestUtils.TEST_BIND_HOST,
+      "spark.executorEnv.SPARK_LOCAL_IP" -> TestUtils.TEST_BIND_HOST,
+      // Propagate the host shell PATH into the YARN AM and executor
+      // containers so that native binaries the tests spawn (Rscript for
+      // SparkR, python for PySpark) resolve. YARN's default sanitised PATH
+      // otherwise omits /opt/homebrew/bin on macOS which causes RRunner and
+      // PythonRunner to fail with `error=2, No such file or directory`.
+      "spark.yarn.appMasterEnv.PATH" -> sys.env.getOrElse("PATH", ""),
+      "spark.executorEnv.PATH" -> sys.env.getOrElse("PATH", ""),
       SparkLauncher.DRIVER_MEMORY -> "512m",
       SparkLauncher.EXECUTOR_MEMORY -> "512m",
       SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS -> "-Dtest.appender=console",
@@ -343,7 +357,7 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
     pb.environment().put("LIVY_CONF_DIR", configDir.getAbsolutePath())
     pb.environment().put("HADOOP_CONF_DIR", configDir.getAbsolutePath())
     pb.environment().put("SPARK_CONF_DIR", _sparkConfigDir.getAbsolutePath())
-    pb.environment().put("SPARK_LOCAL_IP", "127.0.0.1")
+    pb.environment().put("SPARK_LOCAL_IP", TestUtils.TEST_BIND_HOST)
 
     val child = pb.start()
 

--- a/repl/src/test/scala/org/apache/livy/repl/BaseSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/BaseSessionSpec.scala
@@ -30,6 +30,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.livy.LivyBaseUnitTestSuite
+import org.apache.livy.client.common.TestUtils
 import org.apache.livy.rsc.RSCConf
 import org.apache.livy.rsc.driver.{Statement, StatementState}
 import org.apache.livy.sessions._
@@ -39,7 +40,11 @@ abstract class BaseSessionSpec(kind: Kind)
 
   implicit val formats = DefaultFormats
 
-  private val rscConf = new RSCConf(new Properties()).set(RSCConf.Entry.SESSION_KIND, kind.toString)
+  private val rscConf = {
+    val props = new Properties()
+    props.setProperty(RSCConf.Entry.RPC_SERVER_ADDRESS.key(), TestUtils.TEST_BIND_HOST)
+    new RSCConf(props).set(RSCConf.Entry.SESSION_KIND, kind.toString)
+  }
 
   private val sparkConf = new SparkConf()
 

--- a/repl/src/test/scala/org/apache/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/ReplDriverSuite.scala
@@ -30,6 +30,7 @@ import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.livy._
+import org.apache.livy.client.common.TestUtils
 import org.apache.livy.rsc.{PingJob, RSCClient, RSCConf}
 import org.apache.livy.sessions.Spark
 
@@ -43,6 +44,7 @@ class ReplDriverSuite extends FunSuite with LivyBaseUnitTestSuite {
       .setConf(SparkLauncher.DRIVER_EXTRA_CLASSPATH, sys.props("java.class.path"))
       .setConf(SparkLauncher.EXECUTOR_EXTRA_CLASSPATH, sys.props("java.class.path"))
       .setConf(RSCConf.Entry.LIVY_JARS.key(), "")
+      .setConf(RSCConf.Entry.RPC_SERVER_ADDRESS.key(), TestUtils.TEST_BIND_HOST)
       .setURI(new URI("rsc:/"))
       .setConf(RSCConf.Entry.DRIVER_CLASS.key(), classOf[ReplDriver].getName())
       .setConf(RSCConf.Entry.SESSION_KIND.key(), Spark.toString)

--- a/rsc/src/test/java/org/apache/livy/rsc/TestSparkClient.java
+++ b/rsc/src/test/java/org/apache/livy/rsc/TestSparkClient.java
@@ -46,6 +46,7 @@ import org.apache.livy.JobHandle;
 import org.apache.livy.LivyClient;
 import org.apache.livy.LivyClientBuilder;
 import org.apache.livy.client.common.Serializer;
+import org.apache.livy.client.common.TestUtils;
 import org.apache.livy.rsc.rpc.RpcException;
 import org.apache.livy.test.jobs.*;
 import static org.apache.livy.rsc.RSCConf.Entry.*;
@@ -80,6 +81,7 @@ public class TestSparkClient {
     conf.put("spark.repl.enableHiveContext", hiveSupport);
     conf.put("spark.sql.catalogImplementation", hiveSupport ? "hive" : "in-memory");
     conf.put(RETAINED_SHARE_VARIABLES.key(), "2");
+    conf.put(RPC_SERVER_ADDRESS.key(), TestUtils.TEST_BIND_HOST);
     return conf;
   }
 

--- a/rsc/src/test/java/org/apache/livy/rsc/rpc/TestRpc.java
+++ b/rsc/src/test/java/org/apache/livy/rsc/rpc/TestRpc.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import org.apache.livy.client.common.TestUtils;
 import org.apache.livy.rsc.FutureListener;
 import org.apache.livy.rsc.RSCConf;
 import org.apache.livy.rsc.Utils;
@@ -57,6 +58,7 @@ public class TestRpc {
   public void setUp() {
     closeables = new ArrayList<>();
     emptyConfig = new RSCConf(null);
+    emptyConfig.set(RPC_SERVER_ADDRESS, TestUtils.TEST_BIND_HOST);
   }
 
   @After

--- a/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTest.scala
+++ b/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTest.scala
@@ -37,6 +37,7 @@ import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.scalatest.concurrent.ScalaFutures
 
 import org.apache.livy.LivyBaseUnitTestSuite
+import org.apache.livy.client.common.TestUtils
 import org.apache.livy.rsc.RSCConf.Entry._
 
 class ScalaClientTest extends FunSuite
@@ -188,6 +189,7 @@ object ScalaClientTest {
     }
     conf.put(CLIENT_SHUTDOWN_TIMEOUT.key(), "30s")
     conf.put(LIVY_JARS.key, "")
+    conf.put(RPC_SERVER_ADDRESS.key(), TestUtils.TEST_BIND_HOST)
     conf
   }
 

--- a/server/src/test/scala/org/apache/livy/server/interactive/BaseInteractiveServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/BaseInteractiveServletSpec.scala
@@ -24,6 +24,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.spark.launcher.SparkLauncher
 
 import org.apache.livy.LivyConf
+import org.apache.livy.client.common.TestUtils
 import org.apache.livy.rsc.RSCConf
 import org.apache.livy.server.BaseSessionServletSpec
 import org.apache.livy.sessions.{Kind, SessionKindModule, Spark}
@@ -65,6 +66,7 @@ abstract class BaseInteractiveServletSpec
     request.conf = extraConf ++ Map(
       RSCConf.Entry.LIVY_JARS.key() -> "",
       RSCConf.Entry.CLIENT_IN_PROCESS.key() -> inProcess.toString,
+      RSCConf.Entry.RPC_SERVER_ADDRESS.key() -> TestUtils.TEST_BIND_HOST,
       SparkLauncher.SPARK_MASTER -> "local",
       SparkLauncher.DRIVER_EXTRA_CLASSPATH -> classpath,
       SparkLauncher.EXECUTOR_EXTRA_CLASSPATH -> classpath

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -34,6 +34,7 @@ import org.scalatest.concurrent.Eventually._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{ExecuteRequest, JobHandle, LivyBaseUnitTestSuite, LivyConf}
+import org.apache.livy.client.common.TestUtils
 import org.apache.livy.rsc.{PingJob, RSCClient, RSCConf}
 import org.apache.livy.rsc.driver.StatementState
 import org.apache.livy.server.AccessManager
@@ -68,7 +69,8 @@ class InteractiveSessionSpec extends FunSpec
     req.name = Some("InteractiveSessionSpec")
     req.conf = Map(
       SparkLauncher.DRIVER_EXTRA_CLASSPATH -> sys.props("java.class.path"),
-      RSCConf.Entry.LIVY_JARS.key() -> ""
+      RSCConf.Entry.LIVY_JARS.key() -> "",
+      RSCConf.Entry.RPC_SERVER_ADDRESS.key() -> TestUtils.TEST_BIND_HOST
     )
     InteractiveSession.create(0, None, null, None, livyConf, accessManager, req,
       sessionStore, None, None, mockApp)

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerBaseTest.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerBaseTest.scala
@@ -24,6 +24,8 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import org.apache.livy.LivyConf
 import org.apache.livy.LivyConf.{LIVY_SPARK_SCALA_VERSION, LIVY_SPARK_VERSION}
+import org.apache.livy.client.common.TestUtils
+import org.apache.livy.rsc.RSCConf
 import org.apache.livy.server.AccessManager
 import org.apache.livy.server.recovery.{SessionStore, StateStore}
 import org.apache.livy.sessions.InteractiveSessionManager
@@ -56,6 +58,7 @@ abstract class ThriftServerBaseTest extends FunSuite with BeforeAndAfterAll {
     Class.forName(classOf[HiveDriver].getCanonicalName)
     livyConf.set(LivyConf.THRIFT_TRANSPORT_MODE, mode.toString)
     livyConf.set(LivyConf.THRIFT_SERVER_PORT, port)
+    livyConf.set(RSCConf.Entry.RPC_SERVER_ADDRESS.key(), TestUtils.TEST_BIND_HOST)
 
     // Set formatted Spark and Scala version into livy configuration, this will be used by
     // session creation.

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ThriftSessionTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ThriftSessionTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.*;
 import org.apache.livy.Job;
 import org.apache.livy.LivyClient;
 import org.apache.livy.LivyClientBuilder;
+import org.apache.livy.client.common.TestUtils;
 import static org.apache.livy.rsc.RSCConf.Entry.*;
 
 public class ThriftSessionTest {
@@ -53,6 +54,7 @@ public class ThriftSessionTest {
     conf.put(SparkLauncher.SPARK_MASTER, "local");
     conf.put("spark.sql.warehouse.dir", warehouse);
     conf.put("spark.sql.catalogImplementation", "in-memory");
+    conf.put(RPC_SERVER_ADDRESS.key(), TestUtils.TEST_BIND_HOST);
 
     livy = new LivyClientBuilder(false)
       .setURI(new URI("rsc:/"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Livy unit-test and integration-test suites do not pass on macOS
today. The root cause is that several Livy and Spark services bind
to the LAN IP returned by InetAddress.getLocalHost, but on macOS
the canonical hostname routinely resolves to a loopback-only
address (or the LAN IP is otherwise unreachable from a peer process
on the same box). As a result the mini-cluster YARN containers and
JDBC clients on the same host cannot reach the server side, and
tests time out with "RSCClient instance stopped" or hang on
"Initial job has not accepted any resources".

The changes below are the minimum set required to turn every Livy
test suite green on macOS developer machine -- both the
unit-test and integration-test runs, on the -Pspark3 profile. Linux
CI hosts already resolve the primary hostname to a routable
address, so 127.0.0.1 is equally valid there.

To avoid hardcoding "127.0.0.1" at every call site, a shared
TestUtils.TEST_BIND_HOST constant is introduced in client-common
(a @Private Java helper class already on the compile classpath of
every affected module) and referenced from every test-scope bind,
so future changes can flip a single location.

### What changed (each item is required for at least one macOS test suite to go green; together they take the whole build to zero failures on macOS)

- **`client-common/TestUtils.java`**: add the
  `TEST_BIND_HOST = "127.0.0.1"` constant with a Javadoc pointing at
  LIVY-1065.

- **`integration-test/MiniCluster.scala`, `MiniLivyMain`**: set
  `livy.server.host`, `livy.server.thrift.bind.host` and
  `livy.rsc.rpc.server.address` to `TEST_BIND_HOST`. The RSC key is
  referenced through the typed
  `RSCConf.Entry.RPC_SERVER_ADDRESS.key()` rather than the raw
  string, matching the rest of the patch. Without these the RSC
  driver inside the YARN AM container cannot reach the Livy server
  on macOS and `JdbcIT` / `InteractiveIT` fail with `RSCClient
  instance stopped`.

- **`integration-test/MiniCluster.scala`, `MiniCluster.deploy()`**:
  set `spark.driver.host`,
  `spark.yarn.appMasterEnv.SPARK_LOCAL_IP` and
  `spark.executorEnv.SPARK_LOCAL_IP` to `TEST_BIND_HOST` in the
  generated `spark-defaults.conf`, and set
  `SPARK_LOCAL_IP=TEST_BIND_HOST` in the child process environment.
  `SPARK_LOCAL_IP` is what the YARN AM driver actually reads on
  macOS; `spark.driver.host` on the submit side alone is not
  honoured in cluster deploy mode. Without these the executor
  never registers with the driver on macOS and `JdbcIT` hangs on
  `Initial job has not accepted any resources`.

- **`integration-test/MiniCluster.scala`, `MiniCluster.deploy()`**:
  also propagate the host shell `PATH` into the YARN AM and
  executor containers (`spark.yarn.appMasterEnv.PATH` /
  `spark.executorEnv.PATH`), so `RRunner` and `PythonRunner` can
  resolve `Rscript` / `python` on macOS — YARN's default sanitised
  `PATH` omits `/opt/homebrew/bin`, which is where Homebrew
  installs the R and Python interpreters that macOS developers
  use, and without it `RRunner` and `PythonRunner` fail with
  `error=2, No such file or directory` in the SparkR / PySpark
  integration tests.

- **Unit-test fixtures**: set
  `RSCConf.Entry.RPC_SERVER_ADDRESS` to `TEST_BIND_HOST` in every
  fixture that spins up an in-process RSC server —
  `BaseSessionSpec`, `ReplDriverSuite`, `TestSparkClient`, `TestRpc`,
  `ScalaClientTest`, `BaseInteractiveServletSpec`,
  `InteractiveSessionSpec`, `ThriftServerBaseTest`,
  `ThriftSessionTest`. Each of these RSC-hosting unit-test classes
  hangs or fails on macOS without the loopback pin (the child
  driver JVM times out contacting the server on the machine's
  routable IP).

- **`client-http/HttpClientSpec.scala`,
  `client-http/LivyConnectionSpec.scala`**: change the `WebServer`
  bind host from `"0.0.0.0"` / `InetAddress.getLocalHost` to
  `TEST_BIND_HOST`, and switch the URIs the tests build to use
  `server.host` so the client and server agree. Drop the now-unused
  `InetAddress` import. Fixes the two HTTP-client suites' timeouts
  on macOS.

- **`thriftserver/ThriftServerBaseTest.scala`**: use the typed
  `RSCConf.Entry.RPC_SERVER_ADDRESS.key()` rather than the raw
  string, matching every other Scala test file in the patch.

## How was this patch tested?

- `mvn -Pthriftserver -Pspark3 -Pscala-2.12 -B verify` locally on
  macOS: all unit-test suites (including `livy-integration-test `, `livy-repl_2.12`,
  `livy-server`, `livy-thriftserver`, `livy-thriftserver-session`,
  `livy-client-http`, `livy-scala-api_2.12`) pass with these
  changes; without them the same suites fail on macOS with
  `RSCClient instance stopped` / connect timeouts to the LAN IP.

```
$ mvn -Pspark3 -Pscala-2.12 -Pthriftserver verify
...

[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 1 licenses.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Livy Project Parent POM 1.0.0-SNAPSHOT:
[INFO] 
[INFO] Livy Project Parent POM ............................ SUCCESS [  1.928 s]
[INFO] livy-api ........................................... SUCCESS [  4.065 s]
[INFO] livy-client-common ................................. SUCCESS [  1.973 s]
[INFO] livy-test-lib ...................................... SUCCESS [  1.762 s]
[INFO] multi-scala-project-root ........................... SUCCESS [  0.625 s]
[INFO] livy-core-parent ................................... SUCCESS [  0.227 s]
[INFO] livy-core_2.12 ..................................... SUCCESS [  2.583 s]
[INFO] livy-rsc ........................................... SUCCESS [ 18.684 s]
[INFO] livy-repl-parent ................................... SUCCESS [  2.064 s]
[INFO] livy-repl_2.12 ..................................... SUCCESS [01:13 min]
[INFO] livy-server ........................................ SUCCESS [03:04 min]
[INFO] livy-thriftserver-session .......................... SUCCESS [  8.502 s]
[INFO] livy-thriftserver .................................. SUCCESS [03:42 min]
[INFO] livy-assembly ...................................... SUCCESS [  3.272 s]
[INFO] livy-client-http ................................... SUCCESS [ 10.390 s]
[INFO] livy-scala-api-parent .............................. SUCCESS [  0.420 s]
[INFO] livy-scala-api_2.12 ................................ SUCCESS [ 17.304 s]
[INFO] livy-integration-test .............................. SUCCESS [15:22 min]
[INFO] livy-coverage-report ............................... SUCCESS [  2.369 s]
[INFO] livy-examples ...................................... SUCCESS [  2.834 s]
[INFO] livy-python-api .................................... SUCCESS [  2.598 s]
[INFO] livy-beeline ....................................... SUCCESS [  1.933 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24:46 min
[INFO] Finished at: 2026-08-10T14:27:48+02:00
[INFO] ------------------------------------------------------------------------
```

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)
