### PR TITLE
[LIVY-1066] Upgrade scalatest to 3.2.9 and scalatra to 2.8.4

### DIFF
--- a/client-http/src/test/scala/org/apache/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/HttpClientSpec.scala
@@ -30,7 +30,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => meq, _}
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfterAll, FunSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpecLike
 import org.scalatra.LifeCycle
 import org.scalatra.servlet.ScalatraListener
 
@@ -49,7 +50,7 @@ import org.apache.livy.utils.AppInfo
  * module, which implements the client session backend. The client servlet has some functionality
  * overridden to avoid creating sub-processes for each seession.
  */
-class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
+class HttpClientSpec extends AnyFunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
 
   import HttpClientSpec._
 

--- a/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
@@ -25,14 +25,15 @@ import org.eclipse.jetty.security._
 import org.eclipse.jetty.security.UserStore
 import org.eclipse.jetty.security.authentication.BasicAuthenticator
 import org.eclipse.jetty.util.security._
-import org.scalatest.{BeforeAndAfterAll, FunSpecLike}
-import org.scalatest.Matchers._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers._
 import org.scalatra.servlet.ScalatraListener
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.server.WebServer
 
-class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
+class LivyConnectionSpec extends AnyFunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
   describe("LivyConnection") {
     def basicAuth(username: String, password: String, realm: String): SecurityHandler = {
       val roles = Array("user")

--- a/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
@@ -25,15 +25,16 @@ import org.eclipse.jetty.security._
 import org.eclipse.jetty.security.UserStore
 import org.eclipse.jetty.security.authentication.BasicAuthenticator
 import org.eclipse.jetty.util.security._
-import org.scalatest.{BeforeAndAfterAll, FunSpecLike}
-import org.scalatest.Matchers._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers._
 import org.scalatra.servlet.ScalatraListener
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.client.common.TestUtils
 import org.apache.livy.server.WebServer
 
-class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
+class LivyConnectionSpec extends AnyFunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
   describe("LivyConnection") {
     def basicAuth(username: String, password: String, realm: String): SecurityHandler = {
       val roles = Array("user")

--- a/core/src/test/scala/org/apache/livy/EOLUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/livy/EOLUtilsSuite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.livy
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class EOLUtilsSuite extends FunSuite with LivyBaseUnitTestSuite {
+class EOLUtilsSuite extends AnyFunSuite with LivyBaseUnitTestSuite {
 
   test("check EOL") {
     val s1 = "test\r\ntest"

--- a/integration-test/src/main/scala/org/apache/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -38,9 +38,11 @@ import org.apache.http.client.params.AuthPolicy
 import org.apache.http.impl.auth.BasicSchemeFactory
 import org.apache.http.impl.auth.SPNegoSchemeFactory
 import org.apache.http.impl.client.DefaultHttpClient
-import org.scalatest._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with BeforeAndAfterAll {
+abstract class BaseIntegrationTestSuite extends AnyFunSuite with Matchers with BeforeAndAfterAll {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   var cluster: Cluster = _

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,21 @@
     <libthrift.version>0.9.3</libthrift.version>
     <log4j.version>2.26.0</log4j.version>
     <kryo.version>4.0.2</kryo.version>
-    <metrics.version>3.1.0</metrics.version>
+    <!-- Scalatra 2.8.x pulls in metrics-servlets 4.2.x; keeping metrics-core
+         and metrics-healthchecks on 3.1.0 causes a NoClassDefFoundError for
+         HealthCheckFilter at runtime (the class moved in Dropwizard 4.x). -->
+    <metrics.version>4.2.19</metrics.version>
     <mockito.version>1.10.19</mockito.version>
     <netty.version>4.1.86.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <scalatest.version>3.0.8</scalatest.version>
-    <scalatra.version>2.6.5</scalatra.version>
+    <!-- Scalatest 3.2.9 is required by Scalatra 2.8.x (needed for Scala
+         2.13 support). All test suites are written against the 3.2 API,
+         where types like `FunSuite`/`Matchers` moved into subpackages. -->
+    <scalatest.version>3.2.9</scalatest.version>
+    <!-- The scalatestplus mockito artifact uses a four-part version that tracks
+         scalatest (e.g. 3.2.9.0 for scalatest 3.2.9). -->
+    <scalatestplus.mockito.version>3.2.9.0</scalatestplus.mockito.version>
+    <scalatra.version>2.8.4</scalatra.version>
     <java.version>1.8</java.version>
     <owasp.version>12.1.9</owasp.version>
     <extraJavaTestArgs>
@@ -260,6 +269,15 @@
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
       <version>${scalatest.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- ScalaTest 3.2 moved `MockitoSugar.mock` into a separate scalatestplus
+         artifact. -->
+    <dependency>
+      <groupId>org.scalatestplus</groupId>
+      <artifactId>mockito-3-4_${scala.binary.version}</artifactId>
+      <version>${scalatestplus.mockito.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,18 @@
     <libthrift.version>0.9.3</libthrift.version>
     <log4j.version>2.26.0</log4j.version>
     <kryo.version>4.0.2</kryo.version>
-    <metrics.version>3.1.0</metrics.version>
+    <!-- Scalatra 2.8.x pulls in metrics-servlets 4.2.x; keeping metrics-core
+         and metrics-healthchecks on 3.1.0 causes a NoClassDefFoundError for
+         HealthCheckFilter at runtime (the class moved in Dropwizard 4.x). -->
+    <metrics.version>4.2.19</metrics.version>
     <mockito.version>1.10.19</mockito.version>
     <netty.version>4.1.86.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <scalatest.version>3.0.8</scalatest.version>
-    <scalatra.version>2.6.5</scalatra.version>
+    <!-- Scalatest 3.2.9 is required by Scalatra 2.8.x (needed for Scala
+         2.13 support). All test suites are written against the 3.2 API,
+         where types like `FunSuite`/`Matchers` moved into subpackages. -->
+    <scalatest.version>3.2.9</scalatest.version>
+    <scalatra.version>2.8.4</scalatra.version>
     <java.version>1.8</java.version>
     <owasp.version>12.1.9</owasp.version>
     <extraJavaTestArgs>
@@ -260,6 +266,15 @@
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
       <version>${scalatest.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- ScalaTest 3.2 moved `MockitoSugar.mock` into a separate scalatestplus
+         artifact. The 3.2.9.0 release corresponds to scalatest 3.2.9. -->
+    <dependency>
+      <groupId>org.scalatestplus</groupId>
+      <artifactId>mockito-3-4_${scala.binary.version}</artifactId>
+      <version>3.2.9.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/repl/scala-2.12/src/test/scala/org/apache/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.12/src/test/scala/org/apache/livy/repl/SparkInterpreterSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.livy.repl
 
-import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.LivyBaseUnitTestSuite
 
-class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
+class SparkInterpreterSpec extends AnyFunSpec with Matchers with LivyBaseUnitTestSuite {
   describe("SparkInterpreter") {
     val interpreter = new SparkInterpreter(null)
 

--- a/repl/src/test/scala/org/apache/livy/repl/BaseInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/BaseInterpreterSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.livy.repl
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.LivyBaseUnitTestSuite
 
-abstract class BaseInterpreterSpec extends FlatSpec with Matchers with LivyBaseUnitTestSuite {
+abstract class BaseInterpreterSpec extends AnyFlatSpec with Matchers with LivyBaseUnitTestSuite {
 
   def createInterpreter(): Interpreter
 

--- a/repl/src/test/scala/org/apache/livy/repl/BaseSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/BaseSessionSpec.scala
@@ -26,8 +26,9 @@ import scala.language.postfixOps
 
 import org.apache.spark.SparkConf
 import org.json4s._
-import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.LivyBaseUnitTestSuite
 import org.apache.livy.rsc.RSCConf
@@ -35,7 +36,7 @@ import org.apache.livy.rsc.driver.{Statement, StatementState}
 import org.apache.livy.sessions._
 
 abstract class BaseSessionSpec(kind: Kind)
-    extends FlatSpec with Matchers with LivyBaseUnitTestSuite {
+    extends AnyFlatSpec with Matchers with LivyBaseUnitTestSuite {
 
   implicit val formats = DefaultFormats
 

--- a/repl/src/test/scala/org/apache/livy/repl/BaseSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/BaseSessionSpec.scala
@@ -26,8 +26,9 @@ import scala.language.postfixOps
 
 import org.apache.spark.SparkConf
 import org.json4s._
-import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.LivyBaseUnitTestSuite
 import org.apache.livy.client.common.TestUtils
@@ -36,7 +37,7 @@ import org.apache.livy.rsc.driver.{Statement, StatementState}
 import org.apache.livy.sessions._
 
 abstract class BaseSessionSpec(kind: Kind)
-    extends FlatSpec with Matchers with LivyBaseUnitTestSuite {
+    extends AnyFlatSpec with Matchers with LivyBaseUnitTestSuite {
 
   implicit val formats = DefaultFormats
 

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -20,8 +20,10 @@ package org.apache.livy.repl
 import org.apache.spark.SparkConf
 import org.json4s.{DefaultFormats, JNull, JValue}
 import org.json4s.JsonDSL._
-import org.scalatest._
+import org.scalatest.{BeforeAndAfterAll, Outcome}
 import org.scalatest.Inside.inside
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.rsc.driver.SparkEntries
 import org.apache.livy.sessions._

--- a/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
@@ -19,7 +19,9 @@ package org.apache.livy.repl
 
 import org.json4s.Extraction
 import org.json4s.jackson.JsonMethods.parse
-import org.scalatest._
+import org.scalatest.{BeforeAndAfterAll, Outcome}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.sessions._
 

--- a/repl/src/test/scala/org/apache/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/ReplDriverSuite.scala
@@ -26,14 +26,14 @@ import scala.language.postfixOps
 import org.apache.spark.launcher.SparkLauncher
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy._
 import org.apache.livy.rsc.{PingJob, RSCClient, RSCConf}
 import org.apache.livy.sessions.Spark
 
-class ReplDriverSuite extends FunSuite with LivyBaseUnitTestSuite {
+class ReplDriverSuite extends AnyFunSuite with LivyBaseUnitTestSuite {
 
   private implicit val formats = DefaultFormats
 

--- a/repl/src/test/scala/org/apache/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/ReplDriverSuite.scala
@@ -26,15 +26,15 @@ import scala.language.postfixOps
 import org.apache.spark.launcher.SparkLauncher
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy._
 import org.apache.livy.client.common.TestUtils
 import org.apache.livy.rsc.{PingJob, RSCClient, RSCConf}
 import org.apache.livy.sessions.Spark
 
-class ReplDriverSuite extends FunSuite with LivyBaseUnitTestSuite {
+class ReplDriverSuite extends AnyFunSuite with LivyBaseUnitTestSuite {
 
   private implicit val formats = DefaultFormats
 

--- a/repl/src/test/scala/org/apache/livy/repl/SessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SessionSpec.scala
@@ -21,9 +21,10 @@ import java.util.Properties
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 
 import org.apache.spark.SparkConf
-import org.scalatest.{BeforeAndAfter, FunSpec}
-import org.scalatest.Matchers._
+import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.Eventually
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.time._
 
 import org.apache.livy.LivyBaseUnitTestSuite
@@ -31,7 +32,8 @@ import org.apache.livy.repl.Interpreter.ExecuteResponse
 import org.apache.livy.rsc.RSCConf
 import org.apache.livy.sessions._
 
-class SessionSpec extends FunSpec with Eventually with LivyBaseUnitTestSuite with BeforeAndAfter {
+class SessionSpec extends AnyFunSpec with Eventually
+  with LivyBaseUnitTestSuite with BeforeAndAfter {
   override implicit val patienceConfig =
     PatienceConfig(timeout = scaled(Span(30, Seconds)), interval = scaled(Span(100, Millis)))
 

--- a/repl/src/test/scala/org/apache/livy/repl/SparkRInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SparkRInterpreterSpec.scala
@@ -20,7 +20,9 @@ package org.apache.livy.repl
 import org.apache.spark.SparkConf
 import org.json4s.DefaultFormats
 import org.json4s.JsonDSL._
-import org.scalatest._
+import org.scalatest.{BeforeAndAfterAll, Outcome}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.rsc.driver.SparkEntries
 

--- a/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTest.scala
+++ b/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTest.scala
@@ -33,13 +33,14 @@ import scala.util.{Failure, Success}
 
 import org.apache.spark.SparkFiles
 import org.apache.spark.launcher.SparkLauncher
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy.LivyBaseUnitTestSuite
 import org.apache.livy.rsc.RSCConf.Entry._
 
-class ScalaClientTest extends FunSuite
+class ScalaClientTest extends AnyFunSuite
   with ScalaFutures
   with BeforeAndAfter
   with LivyBaseUnitTestSuite {

--- a/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTest.scala
+++ b/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTest.scala
@@ -33,14 +33,15 @@ import scala.util.{Failure, Success}
 
 import org.apache.spark.SparkFiles
 import org.apache.spark.launcher.SparkLauncher
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy.LivyBaseUnitTestSuite
 import org.apache.livy.client.common.TestUtils
 import org.apache.livy.rsc.RSCConf.Entry._
 
-class ScalaClientTest extends FunSuite
+class ScalaClientTest extends AnyFunSuite
   with ScalaFutures
   with BeforeAndAfter
   with LivyBaseUnitTestSuite {

--- a/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTestUtils.scala
+++ b/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTestUtils.scala
@@ -22,12 +22,13 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy.LivyBaseUnitTestSuite
 
-object ScalaClientTestUtils extends FunSuite with LivyBaseUnitTestSuite {
+object ScalaClientTestUtils extends AnyFunSuite with LivyBaseUnitTestSuite {
 
   val Timeout = 40
 

--- a/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaJobHandleTest.scala
+++ b/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaJobHandleTest.scala
@@ -26,13 +26,14 @@ import scala.util.{Failure, Success}
 
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy.{JobHandle, LivyBaseUnitTestSuite}
 import org.apache.livy.JobHandle.{Listener, State}
 
-class ScalaJobHandleTest extends FunSuite
+class ScalaJobHandleTest extends AnyFunSuite
   with ScalaFutures
   with BeforeAndAfter
   with LivyBaseUnitTestSuite {

--- a/server/src/test/scala/org/apache/livy/server/AccessManagerSuite.scala
+++ b/server/src/test/scala/org/apache/livy/server/AccessManagerSuite.scala
@@ -17,11 +17,12 @@
 
 package org.apache.livy.server
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class AccessManagerSuite extends FunSuite with Matchers with LivyBaseUnitTestSuite {
+class AccessManagerSuite extends AnyFunSuite with Matchers with LivyBaseUnitTestSuite {
   import LivyConf._
 
   private val viewUsers = Seq("user1", "user2", "user3")

--- a/server/src/test/scala/org/apache/livy/server/ApiVersioningSupportSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/ApiVersioningSupportSpec.scala
@@ -19,13 +19,14 @@ package org.apache.livy.server
 
 import javax.servlet.http.HttpServletResponse
 
-import org.scalatest.FunSpecLike
+import org.scalatest.funspec.AnyFunSpecLike
 import org.scalatra.ScalatraServlet
 import org.scalatra.test.scalatest.ScalatraSuite
 
 import org.apache.livy.LivyBaseUnitTestSuite
 
-class ApiVersioningSupportSpec extends ScalatraSuite with FunSpecLike with LivyBaseUnitTestSuite {
+class ApiVersioningSupportSpec extends ScalatraSuite with AnyFunSpecLike
+    with LivyBaseUnitTestSuite {
   val LatestVersionOutput = "latest"
 
   object FakeApiVersions extends Enumeration {

--- a/server/src/test/scala/org/apache/livy/server/BaseJsonServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/BaseJsonServletSpec.scala
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletResponse._
 import scala.reflect.ClassTag
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.scalatest.FunSpecLike
+import org.scalatest.funspec.AnyFunSpecLike
 import org.scalatra.test.scalatest.ScalatraSuite
 
 import org.apache.livy.LivyBaseUnitTestSuite
@@ -38,7 +38,7 @@ import org.apache.livy.LivyBaseUnitTestSuite
  * `Unit`, and the `response` object should be checked directly.
  */
 abstract class BaseJsonServletSpec extends ScalatraSuite
-  with FunSpecLike with LivyBaseUnitTestSuite {
+  with AnyFunSpecLike with LivyBaseUnitTestSuite {
 
   protected val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/org/apache/livy/server/SecurityHeadersFilterSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SecurityHeadersFilterSpec.scala
@@ -22,12 +22,13 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.{atLeastOnce, verify}
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class SecurityHeadersFilterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
+class SecurityHeadersFilterSpec extends AnyFunSpec with Matchers with LivyBaseUnitTestSuite {
 
   val requiredHeaders = Set("X-Content-Type-Options", "X-Frame-Options", "X-XSS-Protection",
     "Content-Security-Policy")

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
@@ -26,7 +26,8 @@ import scala.concurrent.duration.Duration
 import org.mockito.Matchers
 import org.mockito.Matchers.anyObject
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, FunSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf, Utils}
@@ -36,9 +37,9 @@ import org.apache.livy.sessions.SessionState
 import org.apache.livy.utils.{AppInfo, Clock, SparkApp}
 
 class BatchSessionSpec
-  extends FunSpec
+  extends AnyFunSpec
   with BeforeAndAfter
-  with org.scalatest.Matchers
+  with org.scalatest.matchers.should.Matchers
   with LivyBaseUnitTestSuite {
 
   val script: Path = {

--- a/server/src/test/scala/org/apache/livy/server/batch/CreateBatchRequestSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/CreateBatchRequestSpec.scala
@@ -18,11 +18,11 @@
 package org.apache.livy.server.batch
 
 import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 import org.apache.livy.LivyBaseUnitTestSuite
 
-class CreateBatchRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
+class CreateBatchRequestSpec extends AnyFunSpec with LivyBaseUnitTestSuite {
 
   private val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/org/apache/livy/server/interactive/CreateInteractiveRequestSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/CreateInteractiveRequestSpec.scala
@@ -18,12 +18,12 @@
 package org.apache.livy.server.interactive
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 import org.apache.livy.LivyBaseUnitTestSuite
 import org.apache.livy.sessions.{PySpark, SessionKindModule}
 
-class CreateInteractiveRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
+class CreateInteractiveRequestSpec extends AnyFunSpec with LivyBaseUnitTestSuite {
 
   private val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -29,8 +29,10 @@ import org.json4s.jackson.JsonMethods.parse
 import org.mockito.{Matchers => MockitoMatchers}
 import org.mockito.Matchers._
 import org.mockito.Mockito.{atLeastOnce, verify, when}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{ExecuteRequest, JobHandle, LivyBaseUnitTestSuite, LivyConf}
@@ -41,7 +43,7 @@ import org.apache.livy.server.recovery.SessionStore
 import org.apache.livy.sessions.{PySpark, SessionState, Spark}
 import org.apache.livy.utils.{AppInfo, SparkApp}
 
-class InteractiveSessionSpec extends FunSpec
+class InteractiveSessionSpec extends AnyFunSpec
     with Matchers with BeforeAndAfterAll with LivyBaseUnitTestSuite {
 
   private val livyConf = new LivyConf()

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -29,8 +29,10 @@ import org.json4s.jackson.JsonMethods.parse
 import org.mockito.{Matchers => MockitoMatchers}
 import org.mockito.Matchers._
 import org.mockito.Mockito.{atLeastOnce, verify, when}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{ExecuteRequest, JobHandle, LivyBaseUnitTestSuite, LivyConf}
@@ -42,7 +44,7 @@ import org.apache.livy.server.recovery.SessionStore
 import org.apache.livy.sessions.{PySpark, SessionState, Spark}
 import org.apache.livy.utils.{AppInfo, SparkApp}
 
-class InteractiveSessionSpec extends FunSpec
+class InteractiveSessionSpec extends AnyFunSpec
     with Matchers with BeforeAndAfterAll with LivyBaseUnitTestSuite {
 
   private val livyConf = new LivyConf()

--- a/server/src/test/scala/org/apache/livy/server/interactive/SessionHeartbeatSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/SessionHeartbeatSpec.scala
@@ -22,8 +22,9 @@ import scala.concurrent.Future
 import scala.language.postfixOps
 
 import org.mockito.Mockito.{never, verify, when}
-import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.LivyConf
@@ -31,7 +32,7 @@ import org.apache.livy.server.recovery.SessionStore
 import org.apache.livy.sessions.{Session, SessionManager}
 import org.apache.livy.sessions.Session.RecoveryMetadata
 
-class SessionHeartbeatSpec extends FunSpec with Matchers {
+class SessionHeartbeatSpec extends AnyFunSpec with Matchers {
   describe("SessionHeartbeat") {
     class TestHeartbeat(override val heartbeatTimeout: FiniteDuration) extends SessionHeartbeat {}
 

--- a/server/src/test/scala/org/apache/livy/server/recovery/BlackholeStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/BlackholeStateStoreSpec.scala
@@ -17,13 +17,13 @@
 
 package org.apache.livy.server.recovery
 
-import org.scalatest.FunSpec
-import org.scalatest.Matchers._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.server.batch.BatchRecoveryMetadata
 
-class BlackholeStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
+class BlackholeStateStoreSpec extends AnyFunSpec with LivyBaseUnitTestSuite {
   describe("BlackholeStateStore") {
     val stateStore = new BlackholeStateStore(new LivyConf())
 

--- a/server/src/test/scala/org/apache/livy/server/recovery/FileSystemStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/FileSystemStateStoreSpec.scala
@@ -31,13 +31,13 @@ import org.mockito.Mockito.{atLeastOnce, spy, verify, when}
 import org.mockito.internal.matchers.Equals
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.FunSpec
-import org.scalatest.Matchers._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class FileSystemStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
+class FileSystemStateStoreSpec extends AnyFunSpec with LivyBaseUnitTestSuite {
   describe("FileSystemStateStore") {
     def pathEq(wantedPath: String): Path = argThat(new ArgumentMatcher[Path] {
       private val matcher = new Equals(wantedPath)

--- a/server/src/test/scala/org/apache/livy/server/recovery/SessionStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/SessionStoreSpec.scala
@@ -20,14 +20,14 @@ package org.apache.livy.server.recovery
 import scala.util.Success
 
 import org.mockito.Mockito._
-import org.scalatest.FunSpec
-import org.scalatest.Matchers._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.sessions.Session.RecoveryMetadata
 
-class SessionStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
+class SessionStoreSpec extends AnyFunSpec with LivyBaseUnitTestSuite {
   describe("SessionStore") {
     case class TestRecoveryMetadata(id: Int) extends RecoveryMetadata
 

--- a/server/src/test/scala/org/apache/livy/server/recovery/StateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/StateStoreSpec.scala
@@ -17,13 +17,14 @@
 
 package org.apache.livy.server.recovery
 
-import org.scalatest.{BeforeAndAfter, FunSpec}
-import org.scalatest.Matchers._
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.sessions.SessionManager
 
-class StateStoreSpec extends FunSpec with BeforeAndAfter with LivyBaseUnitTestSuite {
+class StateStoreSpec extends AnyFunSpec with BeforeAndAfter with LivyBaseUnitTestSuite {
   describe("StateStore") {
     after {
       StateStore.cleanup()

--- a/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
@@ -26,13 +26,13 @@ import org.apache.curator.framework.state.{ConnectionState, ConnectionStateListe
 import org.apache.zookeeper.data.Stat
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
-import org.scalatest.FunSpec
-import org.scalatest.Matchers._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
+class ZooKeeperStateStoreSpec extends AnyFunSpec with LivyBaseUnitTestSuite {
   describe("ZooKeeperStateStore") {
     case class TestFixture(stateStore: ZooKeeperStateStore, curatorClient: CuratorFramework)
     val conf = new LivyConf()

--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -23,8 +23,9 @@ import scala.language.postfixOps
 import scala.util.{Failure, Try}
 
 import org.mockito.Mockito.{doReturn, never, verify, when}
-import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
@@ -33,7 +34,7 @@ import org.apache.livy.server.interactive.{InteractiveRecoveryMetadata, Interact
 import org.apache.livy.server.recovery.SessionStore
 import org.apache.livy.sessions.Session.RecoveryMetadata
 
-class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
+class SessionManagerSpec extends AnyFunSpec with Matchers with LivyBaseUnitTestSuite {
   implicit def executor: ExecutionContext = ExecutionContext.global
 
   private def createSessionManager(livyConf: LivyConf = new LivyConf())

--- a/server/src/test/scala/org/apache/livy/sessions/SessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionSpec.scala
@@ -19,11 +19,11 @@ package org.apache.livy.sessions
 
 import java.net.URI
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class SessionSpec extends FunSuite with LivyBaseUnitTestSuite {
+class SessionSpec extends AnyFunSuite with LivyBaseUnitTestSuite {
 
   test("use default fs in paths") {
     val conf = new LivyConf(false)

--- a/server/src/test/scala/org/apache/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/org/apache/livy/utils/LivySparkUtilsSuite.scala
@@ -17,14 +17,14 @@
 
 package org.apache.livy.utils
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.LivyConf._
 import org.apache.livy.server.LivyServer
 
-class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSuite {
+class LivySparkUtilsSuite extends AnyFunSuite with Matchers with LivyBaseUnitTestSuite {
 
   import LivySparkUtils._
 

--- a/server/src/test/scala/org/apache/livy/utils/SparkAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkAppSpec.scala
@@ -23,11 +23,11 @@ import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.security.alias.CredentialProviderFactory
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class SparkAppSpec extends FunSpec with LivyBaseUnitTestSuite {
+class SparkAppSpec extends AnyFunSpec with LivyBaseUnitTestSuite {
 
   private val providerPathKey = "spark.hadoop.hadoop.security.credential.provider.path"
   private val truststorePasswordKey = "spark.hadoop.hive.metastore.truststore.password"

--- a/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
@@ -22,13 +22,14 @@ import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.api.model.networking.v1.{Ingress, IngressRule, IngressSpec}
 import io.fabric8.kubernetes.client.KubernetesClient
 import org.mockito.Mockito.when
-import org.scalatest.{BeforeAndAfterAll, FunSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.mockito.MockitoSugar._
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.utils.KubernetesConstants.SPARK_APP_TAG_LABEL
 
-class SparkKubernetesAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAndAfterAll {
+class SparkKubernetesAppSpec extends AnyFunSpec with LivyBaseUnitTestSuite with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -36,13 +36,13 @@ import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.concurrent.Eventually
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf, Utils}
 import org.apache.livy.utils.SparkApp._
 
-class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
+class SparkYarnAppSpec extends AnyFunSpec with LivyBaseUnitTestSuite {
   private def cleanupThread(t: Thread)(f: => Unit) = {
     try { f } finally { t.interrupt() }
   }

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerBaseTest.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerBaseTest.scala
@@ -20,7 +20,8 @@ package org.apache.livy.thriftserver
 import java.sql.{Connection, DriverManager, Statement}
 
 import org.apache.hive.jdbc.HiveDriver
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy.LivyConf
 import org.apache.livy.LivyConf.{LIVY_SPARK_SCALA_VERSION, LIVY_SPARK_VERSION}
@@ -33,7 +34,7 @@ object ServerMode extends Enumeration {
   val binary, http = Value
 }
 
-abstract class ThriftServerBaseTest extends FunSuite with BeforeAndAfterAll {
+abstract class ThriftServerBaseTest extends AnyFunSuite with BeforeAndAfterAll {
   def mode: ServerMode.Value
   def port: Int
 

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerBaseTest.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerBaseTest.scala
@@ -20,7 +20,8 @@ package org.apache.livy.thriftserver
 import java.sql.{Connection, DriverManager, Statement}
 
 import org.apache.hive.jdbc.HiveDriver
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.livy.LivyConf
 import org.apache.livy.LivyConf.{LIVY_SPARK_SCALA_VERSION, LIVY_SPARK_VERSION}
@@ -35,7 +36,7 @@ object ServerMode extends Enumeration {
   val binary, http = Value
 }
 
-abstract class ThriftServerBaseTest extends FunSuite with BeforeAndAfterAll {
+abstract class ThriftServerBaseTest extends AnyFunSuite with BeforeAndAfterAll {
   def mode: ServerMode.Value
   def port: Int
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade scalatest 3.0.8 -> 3.2.9 and scalatra 2.6.5 -> 2.8.4. Both upgrades are prerequisites for Spark 4 / Scala 2.13 support (parent JIRA LIVY-1041) and are split into a dedicated commit to keep test migrations separate from core Spark 4 source changes for easier review.

Scalatest 3.0.8 -> 3.2.9:
- Migrate FunSuite/FunSpec/FunSpecLike/FlatSpec test classes to their 3.2 successors AnyFunSuite/AnyFunSpec/AnyFunSpecLike/AnyFlatSpec.
- Move `org.scalatest.Matchers` to `org.scalatest.matchers.should.Matchers`.
- Add `org.scalatestplus:mockito-3-4_${scala.binary.version}:3.2.9.0`, since scalatest 3.2 moved `MockitoSugar.mock` into a separate scalatestplus artifact.

Scalatra 2.6.5 -> 2.8.4:
- Bump `metrics.version` 3.1.0 -> 4.2.19: scalatra 2.8.x's metrics-servlets pulls in Dropwizard metrics 4.x, and keeping metrics-core / metrics-healthchecks at 3.1.0 causes a NoClassDefFoundError for HealthCheckFilter at runtime.

## How was this patch tested?

- Unit tests: `mvn verify -Pspark3 -Pscala-2.12 -Pthriftserver` passes on JDK 8/17 for all modules with the migrated ScalaTest 3.2 test suites (matching what was verified as part of the parent LIVY-1041 branch).
- The metrics 4.2.19 bump is tested by the integration test suite (`mvn integration-test -Pspark3 -Pscala-2.12 -pl :livy-integration-test`), which previously failed with `NoClassDefFoundError: com/codahale/metrics/servlets/HealthCheckFilter` on MiniCluster startup and now passes.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)