### PR TITLE
[LIVY-1074] Update build-ci-image workflow, Dockerfile

### DIFF
--- a/.github/workflows/build-ci-image.yaml
+++ b/.github/workflows/build-ci-image.yaml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       -
         name: Login to the GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -40,7 +40,7 @@ jobs:
       - 
         name: Build and push image
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           context: ./dev/docker/livy-dev-base

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -51,10 +51,10 @@ jobs:
       # Must match the pyenv-installed version in dev/docker/livy-dev-base/Dockerfile.
       # Per each Spark release's python/setup.py: Spark 4.1 supports 3.10..3.14
       # (python_requires=">=3.10"), Spark 3.5 supports 3.8..3.11
-      # (python_requires=">=3.8"). The intersection is 3.10 and 3.11; 3.11.11
-      # is picked as the shared version.
+      # (python_requires=">=3.8"). The intersection is 3.10 and 3.11;
+      # 3.11 is picked as the shared version.
       name: Set Python 3 as default
-      run: pyenv global 3.11.11 && echo "PYSPARK_PYTHON=$(which python3)" >> "$GITHUB_ENV"
+      run: pyenv global 3.11 && echo "PYSPARK_PYTHON=$(which python3)" >> "$GITHUB_ENV"
     -
       name: Set JDK version
       run: update-alternatives --set java ${{ matrix.jdk_path }}

--- a/dev/docker/livy-dev-base/Dockerfile
+++ b/dev/docker/livy-dev-base/Dockerfile
@@ -70,17 +70,17 @@ RUN git clone https://github.com/pyenv/pyenv.git $HOME/pyenv
 ENV PYENV_ROOT=$HOME/pyenv
 ENV PATH="$HOME/pyenv/shims:$HOME/pyenv/bin:$HOME/bin:$PATH"
 
-# Python 3.11.11 is chosen because it is in the officially supported range of
+# Python 3.11 is chosen because it is in the officially supported range of
 # BOTH matrix profiles, per each Spark release's python/setup.py:
 #   * -Pspark4 (Spark 4.1.2): python_requires=">=3.10", classifiers list
 #     3.10 / 3.11 / 3.12 / 3.13 / 3.14.
 #   * -Pspark3 (Spark 3.5.6): python_requires=">=3.8", classifiers list
 #     3.8 / 3.9 / 3.10 / 3.11.
-# The intersection is 3.10 and 3.11; we pick the higher one (3.11.11) so the
+# The intersection is 3.10 and 3.11; we pick the higher one (3.11) so the
 # same image serves both profiles. When bumping this, keep
 # .github/workflows/integration-tests.yaml's `pyenv global` in sync.
-RUN pyenv install -v 3.11.11 && \
-  pyenv global 3.11.11 && \
+RUN pyenv install -v 3.11 && \
+  pyenv global 3.11 && \
   pyenv rehash
 
 # Install build dependencies for python3


### PR DESCRIPTION
## What changes were proposed in this pull request?

The *build-ci-image* GitHub workflow has stopped working because external actions can not rely on tags anymore, using tags prevents the GitHub action from launching. This change fixes the broken workflow by referencing commit hashes instead of tags.

Also included is a small change to the Dockerfile (update Python patch version) to trigger the workflow once merged.

Many thanks for the help with the investigation to Arnav Balyan.

## How was this patch tested?

Tested in a private fork of the main repository.

## Was this patch authored or co-authored using generative AI tooling?

No.