### PR TITLE
[LIVY-1075] Migrate from pytest-runner to direct pytest invocation

### DIFF
--- a/dev/docker/livy-dev-base/Dockerfile
+++ b/dev/docker/livy-dev-base/Dockerfile
@@ -90,7 +90,6 @@ RUN python3 -m pip install -U pip && pip3 install \
         flake8 \
         flaky \
         pytest \
-        pytest-runner \
         requests-kerberos \
         requests \
         responses

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -63,8 +63,8 @@
               <executable>python</executable>
               <skip>${skipTests}</skip>
               <arguments>
-                <argument>setup.py</argument>
-                <argument>test</argument>
+                <argument>-m</argument>
+                <argument>pytest</argument>
               </arguments>
               <environmentVariables>
                 <TMPDIR>${project.build.directory}/tmp</TMPDIR>

--- a/python-api/setup.cfg
+++ b/python-api/setup.cfg
@@ -1,7 +1,5 @@
-[aliases]
-test=pytest
-
 [tool:pytest]
 addopts = --verbose
 python_files = src/test/python/*/*.py
 cache_dir = target/.pytest_cache
+pythonpath = src/main/python

--- a/python-api/setup.py
+++ b/python-api/setup.py
@@ -42,10 +42,9 @@ setup(
     # development". Modern pip (>= 24) rejects `1.0.0-SNAPSHOT` outright with
     # `Invalid version: '1.0.0-SNAPSHOT'` when parsing this package.
     version="1.0.0.dev0",
-    packages=["livy", "livy-tests"],
+    packages=["livy"],
     package_dir={
         "": "src/main/python",
-        "livy-tests": "src/test/python/livy-tests",
     },
     url='https://github.com/apache/livy',
     author_email='user@livy.apache.org',
@@ -55,9 +54,4 @@ setup(
     keywords='livy pyspark development',
     classifiers=CLASSIFIERS,
     install_requires=requirements,
-    extras_require={
-        ':python_version == "2.7"': ['futures']
-    },
-    setup_requires=['pytest-runner', 'flake8'],
-    tests_require=['pytest']
 )


### PR DESCRIPTION
## What changes were proposed in this pull request?

setuptools >= 58 removed the tests_require keyword and pytest-runner's python setup.py test hook. Replace with direct pytest invocation:

- setup.py: remove tests_require, setup_requires, the livy-tests package declaration, and the dead Python 2.7 futures extras_require shim
- pom.xml: replace `python setup.py test` with `python -m pytest`
- setup.cfg: remove defunct [aliases] block; add pythonpath = src/main/python so pytest can resolve the livy package without a prior install step
- Dockerfile: remove pytest-runner from pip install list

## How was this patch tested?

Tested in a forked repository.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude