### PR TITLE
LIVY-1076: Python 3.12 to 3.14 compatibility fixes

### DIFF
--- a/python-api/setup.py
+++ b/python-api/setup.py
@@ -24,7 +24,13 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 

--- a/python-api/src/main/python/livy/client.py
+++ b/python-api/src/main/python/livy/client.py
@@ -379,7 +379,7 @@ class HttpClient:
         path = os.path.join(config_dir, config_file)
         data = "[" + self._CONFIG_SECTION + "]\n" + \
             open(path, encoding='utf-8').read()
-        self._config.readfp(StringIO(data))
+        self._config.read_file(StringIO(data))
 
     def _create_new_session(self, session_conf_dict):
         data = {'kind': 'pyspark', 'conf': session_conf_dict}

--- a/python-api/src/main/python/livy/job_context.py
+++ b/python-api/src/main/python/livy/job_context.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from abc import ABCMeta, abstractproperty, abstractmethod
+from abc import ABCMeta, abstractmethod
 
 
 class JobContext(metaclass=ABCMeta):
@@ -29,7 +29,8 @@ class JobContext(metaclass=ABCMeta):
 
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def sc(self):
         """
         The shared SparkContext instance.
@@ -49,7 +50,8 @@ class JobContext(metaclass=ABCMeta):
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def sql_ctx(self):
         """
         The shared SQLContext instance.
@@ -69,7 +71,8 @@ class JobContext(metaclass=ABCMeta):
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def hive_ctx(self):
         """
         The shared HiveContext instance.
@@ -89,7 +92,8 @@ class JobContext(metaclass=ABCMeta):
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def streaming_ctx(self):
         """
         The shared SparkStreamingContext instance that has already been created
@@ -141,7 +145,8 @@ class JobContext(metaclass=ABCMeta):
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def local_tmp_dir_path(self):
         """"
         Returns
@@ -151,7 +156,8 @@ class JobContext(metaclass=ABCMeta):
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def spark_session(self):
         """
         The shared SparkSession instance.

--- a/python-api/src/main/python/livy/job_handle.py
+++ b/python-api/src/main/python/livy/job_handle.py
@@ -133,7 +133,7 @@ class JobHandle(Future):
                 self._invoke_callbacks()
             else:
                 raise RuntimeError('Future in unexpected state::', self._state)
-            self._job_handle_condition.notifyAll()
+            self._job_handle_condition.notify_all()
 
     def cancel(self):
         """


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR resolves [LIVY-1076](https://issues.apache.org/jira/browse/LIVY-1076) by fixing Python 3.12+ compatibility issues in `livy-python-api`.

Changes:
- **client.py**: Replace deprecated `ConfigParser.readfp()` with `read_file()` (removed in Python 3.12).
- **job_handle.py**: Replace deprecated `notifyAll()` with `notify_all()`.
- **job_context.py**: Replace removed `abc.abstractproperty` with `@property` + `@abstractmethod` on all abstract properties (required for Python 3.12+).
- **setup.py**: Add PyPI classifiers for Python 3.8 through 3.14 to reflect supported versions.

These changes address the deprecation warnings reported in the Jira ticket and ensure the Python client library runs cleanly through Python 3.14, aligning with Spark 4.1’s supported Python range.

Jira: https://issues.apache.org/jira/browse/LIVY-1076

## How was this patch tested?

- Ran livy-python-api unit tests locally:
 `python -m pytest
`
- Verified 12 tests passed with no deprecation warnings on Python 3.12.8:
```
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0 -- /Users/nilesh.rathi/Workspace/upstream/LIVY-1076/livy/python-api/.venv-test-3.12.8/bin/python
cachedir: target/.pytest_cache
rootdir: /Users/nilesh.rathi/Workspace/upstream/LIVY-1076/livy/python-api
configfile: setup.cfg
plugins: flaky-3.8.1
collecting ... collected 12 items
src/test/python/livy-tests/client_test.py::test_create_new_session_without_default_config PASSED [  8%]
src/test/python/livy-tests/client_test.py::test_create_new_session_with_default_config PASSED [ 16%]
src/test/python/livy-tests/client_test.py::test_connect_to_existing_session PASSED [ 25%]
src/test/python/livy-tests/client_test.py::test_submit_job_verify_running_state PASSED [ 33%]
src/test/python/livy-tests/client_test.py::test_submit_job_verify_queued_state PASSED [ 41%]
src/test/python/livy-tests/client_test.py::test_submit_job_verify_succeeded_state PASSED [ 50%]
src/test/python/livy-tests/client_test.py::test_submit_job_verify_failed_state PASSED [ 58%]
src/test/python/livy-tests/client_test.py::test_add_file PASSED          [ 66%]
src/test/python/livy-tests/client_test.py::test_upload_file PASSED       [ 75%]
src/test/python/livy-tests/client_test.py::test_add_pyfile PASSED        [ 83%]
src/test/python/livy-tests/client_test.py::test_upload_pyfile PASSED     [ 91%]
src/test/python/livy-tests/client_test.py::test_add_jar PASSED           [100%]
============================== 12 passed in 0.83s ==============================

```
- Also verified on Python 3.8.19, 3.9.18, and 3.14.0 — all 12 tests passed.
- Ran stricter check with deprecations treated as errors:
`python -m pytest -W error::DeprecationWarning
`

## Was this patch authored or co-authored using generative AI tooling?
Yes. Cursor AI was used to run the local test verification.

