### PR TITLE
[LIVY-1070] Gate session metrics behind livy.server.session-metrics.enabled

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -212,6 +212,10 @@
 # If the Livy Web UI should be included in the Livy Server. Enabled by default.
 # livy.ui.enabled = true
 
+# Whether to register session count gauges (livy.sessions.*) at /metrics/metrics.
+# Disabled by default; set to true to publish session gauges for monitoring.
+# livy.server.session-metrics.enabled = false
+
 # Whether to enable Livy server access control, if it is true then all the income requests will
 # be checked if the requested user has permission.
 # livy.server.access-control.enabled = false

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -595,9 +595,11 @@ Gets the log lines from this batch.
 
 ### GET /metrics/metrics
 
-Returns Codahale (Dropwizard) metrics for the Livy server, including session
-count gauges registered at startup. The metrics servlet is mounted at `/metrics`;
-the JSON payload is served at `/metrics/metrics`.
+Returns Codahale (Dropwizard) metrics for the Livy server. The metrics servlet is
+mounted at `/metrics`; the JSON payload is served at `/metrics/metrics`.
+
+Session count gauges (`livy.sessions.*`) are published only when
+`livy.server.session-metrics.enabled` is set to `true` (default: `false`).
 
 Append `?pretty=true` for formatted output.
 

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -66,6 +66,13 @@ object LivyConf {
 
   val UI_ENABLED = Entry("livy.ui.enabled", true)
 
+  /**
+   * Whether to register session count gauges (livy.sessions.*) in the metrics registry
+   * exposed at /metrics/metrics. When false, the metrics servlet remains available
+   * but session gauges are not published.
+   */
+  val SESSION_METRICS_ENABLED = Entry("livy.server.session-metrics.enabled", false)
+
   val REQUEST_HEADER_SIZE = Entry("livy.server.request-header.size", 131072)
   val RESPONSE_HEADER_SIZE = Entry("livy.server.response-header.size", 131072)
 

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -252,8 +252,10 @@ class LivyServer extends Logging {
             }
 
             context.mountMetricsAdminServlet("/metrics")
-            LivySessionMetrics.register(
-              metricRegistry, interactiveSessionManager, batchSessionManager)
+            if (livyConf.getBoolean(SESSION_METRICS_ENABLED)) {
+              LivySessionMetrics.register(
+                metricRegistry, interactiveSessionManager, batchSessionManager)
+            }
 
             mount(context, livyVersionServlet, "/version/*")
           } catch {

--- a/server/src/test/scala/org/apache/livy/server/LivySessionMetricsSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/LivySessionMetricsSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.livy.LivyBaseUnitTestSuite
+import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.server.batch.BatchSession
 import org.apache.livy.server.interactive.InteractiveSession
 import org.apache.livy.sessions.{BatchSessionManager, InteractiveSessionManager, SessionState}
@@ -82,6 +82,11 @@ class LivySessionMetricsSpec extends AnyFunSpec with Matchers with MockitoSugar
   }
 
   describe("LivySessionMetrics") {
+
+    it("should default session metrics to disabled in LivyConf") {
+      val conf = new LivyConf()
+      conf.getBoolean(LivyConf.SESSION_METRICS_ENABLED) shouldBe false
+    }
 
     it("should register all 18 session gauges") {
       val registry = new MetricRegistry()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds an opt-in configuration flag for LIVY-1070 session monitoring gauges (follow-up to #543).

Problem: PR #543 always registers `LivySessionMetrics` at server startup. Operators and downstream distributions need per-deployment control — session gauges should be disabled by default and enabled only when monitoring is desired.

Solution: Introduce `livy.server.session-metrics.enabled` (default `false`). When `true`, `LivySessionMetrics.register()` runs at startup (same behavior as #543). When `false`, the `/metrics/metrics` servlet remains available but `livy.sessions.*` gauges are not published.

### Changes

File | Change
-- | --
LivyConf.scala | Add `SESSION_METRICS_ENABLED` config entry
LivyServer.scala | Gate `LivySessionMetrics.register()` behind config flag
LivySessionMetricsSpec.scala | Unit tests (+1 case: default disabled)
docs/rest-api.md | Document opt-in behavior for `/metrics/metrics`
conf/livy.conf.template | Commented example config

No changes to `LivySessionMetrics.scala` — the 18 gauges implementation remains as merged in #543.

### Configuration
Default: opt-in disabled
livy.server.session-metrics.enabled=false

Enable session gauges (same 18 gauges as #543)
livy.server.session-metrics.enabled=true


### Behavior when enabled (`livy.server.session-metrics.enabled=true`)

Same 18 gauges as #543:

Overall (3)

* `livy.sessions.total`
* `livy.sessions.active.total`
* `livy.sessions.terminal.total`

Interactive (8)

* `livy.sessions.interactive.total`
* `livy.sessions.interactive.{idle,busy,starting,shutting_down,dead,error,killed}`

Batch (7)

* `livy.sessions.batch.total`
* `livy.sessions.batch.{starting,running,success,dead,error,killed}`

### Design notes

* Minimal follow-up to #543 — only gates existing gauge registration
* Default `false` — opt-in per deployment
* No REST API or session lifecycle behavior changes
* Idempotent registration unchanged from #543 — skips gauge names already present in the registry
* Error-safe callbacks unchanged from #543 — gauge `getValue` returns `0` on exception
* HA note — gauge values reflect the local Livy server instance; in HA deployments only the leader holds active sessions

### Compatibility

* No new endpoints; uses existing `/metrics` AdminServlet
* Behavior change from #543: session gauges are no longer always-on; set `livy.server.session-metrics.enabled=true` to enable them
* When enabled, gauge names and semantics are identical to #543

JIRA: https://issues.apache.org/jira/browse/LIVY-1070

## How was this patch tested?

### Build
mvn package -Pspark3 -Pscala-2.12 -pl server -am
-s /tmp/livy-mvn-central-settings.xml -DskipTests


Result: BUILD SUCCESS

### Unit tests

mvn test -Pspark3 -Pscala-2.12 -pl server
-s /tmp/livy-mvn-central-settings.xml
-Dsuites=org.apache.livy.server.LivySessionMetricsSpec


Result: 9/9 tests passed

Test | Coverage
-- | --
Default session metrics disabled in LivyConf | Opt-in default
All 18 gauge registrations | Registration
Duplicate registration guard | Idempotency
Zero sessions | Empty state
Interactive sessions by state | State counting
Batch sessions by state (incl. succeeded alias) | State counting
Batch succeeded alias | Edge case
Overall totals (total, active, terminal) | Aggregation
Exception fallback returns 0 | Error handling

### Code coverage

JaCoCo agent enabled during test run (`server/target/jacoco/main.exec` generated).

No UI changes in this PR.

## Was this patch authored or co-authored using generative AI tooling?

Yes, this was co-authored using Cursor to help generate the new test case and documentation.